### PR TITLE
Fixed cuda device mismatch in hessian utils

### DIFF
--- a/src/oxford_loss_landscapes/hessian/hessian.py
+++ b/src/oxford_loss_landscapes/hessian/hessian.py
@@ -79,6 +79,10 @@ def eval_hess_vec_prod(vec, params, net, loss_func, inputs, outputs, use_cuda=Fa
         net.cuda()
         vec = [v.cuda() for v in vec]
 
+    device = next(net.parameters()).device
+    inputs = inputs.to(device)
+    outputs = outputs.to(device)
+
     net.eval()
     net.zero_grad() # clears grad for every parameter in the net
     

--- a/src/oxford_loss_landscapes/hessian/hessian_trace.py
+++ b/src/oxford_loss_landscapes/hessian/hessian_trace.py
@@ -15,6 +15,8 @@ def hessian_trace(model, loss_fn, inputs, targets, num_random_vectors=10):
         Estimated Hessian trace (float)
     """
     device = next(model.parameters()).device
+    inputs = inputs.to(device)
+    targets = targets.to(device)
     model.zero_grad()
     outputs = model(inputs)
     loss = loss_fn(outputs, targets)
@@ -34,5 +36,3 @@ def hessian_trace(model, loss_fn, inputs, targets, num_random_vectors=10):
         trace_estimate += sum((hvp_elem * v_elem).sum().item() for hvp_elem, v_elem in zip(hvp, v))
 
     return trace_estimate / num_random_vectors
-
-    


### PR DESCRIPTION
## Summary
- Moved Hessian vector product inputs/targets onto the model's device to eliminate CUDA/CPU mismatches
- Aligned the Hutchinson trace helper with the same device-aware data transfer so trace estimates run on GPU

## Testing
- not run (CUDA hardware unavailable in this environment)